### PR TITLE
Fixes #4, marks SaveChanges virtual, logs changes by default, and adds SaveChangesAsync support

### DIFF
--- a/SampleLogMaker/Controllers/HistoryController.cs
+++ b/SampleLogMaker/Controllers/HistoryController.cs
@@ -42,13 +42,13 @@ namespace SampleLogMaker.Controllers
 						RecordId = int.Parse(log.RecordId),
 						TableName = log.TableName,
 						UserName = log.UserName,
-                        Details = log.LogDetails.Select(x=> new LogDetail { PropertyName = x.ColumnName, OldValue = x.OrginalValue })
+                        Details = log.LogDetails.Select(x=> new LogDetail { PropertyName = x.ColumnName, OldValue = x.OriginalValue })
 					});
 					break;
 
 					case EventType.Modified: //modified
 					vm.Add(new ChangedHistoryVM {
-                        Details = log.LogDetails.Select(x => new LogDetail { PropertyName = x.ColumnName, NewValue = x.NewValue, OldValue = x.OrginalValue }),
+                        Details = log.LogDetails.Select(x => new LogDetail { PropertyName = x.ColumnName, NewValue = x.NewValue, OldValue = x.OriginalValue }),
                         Date = log.EventDateUTC.ToLocalTime().DateTime,
 						LogId = log.AuditLogId,
 						RecordId = int.Parse(log.RecordId),

--- a/Tests/Tracker_Tests.cs
+++ b/Tests/Tracker_Tests.cs
@@ -53,7 +53,7 @@ namespace Tests
             //fetch log
             var log = db.GetLogs<Blog>(blog.Id).ToList().SingleOrDefault(x => x.RecordId == blog.Id.ToString() && x.EventType == EventType.Modified);
             Assert.IsNotNull(log);
-            Assert.IsTrue(log.LogDetails.Any(x => x.ColumnName == "Title" && x.NewValue == newTitle && x.OrginalValue == oldTitle));
+            Assert.IsTrue(log.LogDetails.Any(x => x.ColumnName == "Title" && x.NewValue == newTitle && x.OriginalValue == oldTitle));
         }
 
         [TestMethod]

--- a/TrackerEnabledDbContext.Common/LogAuditor.cs
+++ b/TrackerEnabledDbContext.Common/LogAuditor.cs
@@ -31,7 +31,7 @@ namespace TrackerEnabledDbContext.Common
 
             var newlog = new AuditLog
             {
-                UserName = userName.ToString(),
+                UserName = userName != null ? userName.ToString() : null,
                 EventDateUTC = changeTime,
                 EventType = eventType,
                 TableName = entityType.GetTableName(context),

--- a/TrackerEnabledDbContext.Common/LogDetailsAuditor.cs
+++ b/TrackerEnabledDbContext.Common/LogDetailsAuditor.cs
@@ -29,7 +29,7 @@ namespace TrackerEnabledDbContext.Common
                     yield return new AuditLogDetail
                     {
                         ColumnName = type.GetColumnName(propertyName),
-                        OrginalValue = OriginalValue(propertyName),
+                        OriginalValue = OriginalValue(propertyName),
                         NewValue = CurrentValue(propertyName),
                         Log = _log
                     };

--- a/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
+++ b/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
@@ -12,7 +12,7 @@ namespace TrackerEnabledDbContext.Common.Models
         [MaxLength(256)]
         public string ColumnName { get; set; }
 
-        public string OrginalValue { get; set; }
+        public string OriginalValue { get; set; }
 
         public string NewValue { get; set; }
 

--- a/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
+++ b/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
@@ -33,7 +33,7 @@ namespace TrackerEnabledDbContext.Identity
         /// </summary>
         /// <param name="userName">Username of the logged in identity</param>
         /// <returns>Returns the number of objects written to the underlying database.</returns>
-        public int SaveChanges(object userName)
+        public virtual int SaveChanges(object userName)
         {
             return CommonTracker.SaveChanges(this, userName);
         }

--- a/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
+++ b/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNet.Identity.EntityFramework;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Threading;
+using System.Threading.Tasks;
 using TrackerEnabledDbContext.Common;
 using TrackerEnabledDbContext.Common.Interfaces;
 using TrackerEnabledDbContext.Common.Models;
@@ -28,14 +30,110 @@ namespace TrackerEnabledDbContext.Identity
 
         /// <summary>
         /// This method saves the model changes to the database.
-        /// If the tracker for of table is active, it will also put the old values in tracking table.
+        /// If the tracker for a table is active, it will also put the old values in tracking table.
         /// Always use this method instead of SaveChanges() whenever possible.
         /// </summary>
         /// <param name="userName">Username of the logged in identity</param>
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual int SaveChanges(object userName)
         {
-            return CommonTracker.SaveChanges(this, userName);
+            CommonTracker.AuditChanges(this, userName);
+
+            var addedEntries = CommonTracker.GetAdditions(this);
+            // Call the original SaveChanges(), which will save both the changes made and the audit records...Note that added entry auditing is still remaining.
+            int result = base.SaveChanges();
+            //By now., we have got the primary keys of added entries of added entiries because of the call to savechanges.
+
+            CommonTracker.AuditAdditions(this, userName, addedEntries);
+
+            //save changes to audit of added entries
+            base.SaveChanges();
+            return result;
+        }
+
+
+        /// <summary>
+        /// This method saves the model changes to the database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table.
+        /// </summary>
+        /// <param name="userName">Username of the logged in identity</param>
+        /// <returns>Returns the number of objects written to the underlying database.</returns>
+        public override int SaveChanges()
+        {
+            return this.SaveChanges(null);
+        }
+
+        /// <summary>
+        /// Asynchronously saves all changes made in this context to the underlying database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table.
+        /// </summary>
+        /// <param name="userName">Username of the logged in identity</param>
+        /// <param name="cancellationToken">
+        /// A System.Threading.CancellationToken to observe while waiting for the task
+        /// to complete.
+        /// </param>
+        /// <returns>Returns the number of objects written to the underlying database.</returns>
+        public async virtual Task<int> SaveChangesAsync(object userName, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested == true)
+                cancellationToken.ThrowIfCancellationRequested();
+
+            CommonTracker.AuditChanges(this, userName);
+
+            var addedEntries = CommonTracker.GetAdditions(this);
+
+            // Call the original SaveChanges(), which will save both the changes made and the audit records...Note that added entry auditing is still remaining.
+            int result = await base.SaveChangesAsync(cancellationToken);
+
+            //By now., we have got the primary keys of added entries of added entiries because of the call to savechanges.
+            CommonTracker.AuditAdditions(this, userName, addedEntries);
+
+            //save changes to audit of added entries
+            await base.SaveChangesAsync(cancellationToken);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Asynchronously saves all changes made in this context to the underlying database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table.
+        /// Always use this method instead of SaveChangesAsync() whenever possible.
+        /// </summary>
+        /// <param name="userName">Username of the logged in identity</param>
+        /// <returns>Returns the number of objects written to the underlying database.</returns>
+        public virtual Task<int> SaveChangesAsync(object userName)
+        {
+            return this.SaveChangesAsync(userName, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously saves all changes made in this context to the underlying database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table with null UserName.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous save operation.  The task result
+        /// contains the number of objects written to the underlying database.
+        /// </returns>
+        public override Task<int> SaveChangesAsync()
+        {
+            return this.SaveChangesAsync(null, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously saves all changes made in this context to the underlying database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table with null UserName.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A System.Threading.CancellationToken to observe while waiting for the task
+        /// to complete.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous save operation.  The task result
+        /// contains the number of objects written to the underlying database.
+        /// </returns>
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken)
+        {
+            return this.SaveChangesAsync(cancellationToken);
         }
 
         /// <summary>

--- a/TrackerEnabledDbContext/TrackerContext.cs
+++ b/TrackerEnabledDbContext/TrackerContext.cs
@@ -30,7 +30,7 @@ namespace TrackerEnabledDbContext
         /// </summary>
         /// <param name="userName">Username of the logged in identity</param>
         /// <returns>Returns the number of objects written to the underlying database.</returns>
-        public int SaveChanges(object userName)
+        public virtual int SaveChanges(object userName)
         {
             return CommonTracker.SaveChanges(this, userName);
         }

--- a/TrackerEnabledDbContext/TrackerContext.cs
+++ b/TrackerEnabledDbContext/TrackerContext.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Data.Entity;
+using System.Threading;
+using System.Threading.Tasks;
 using TrackerEnabledDbContext.Common;
 using TrackerEnabledDbContext.Common.Interfaces;
 using TrackerEnabledDbContext.Common.Models;
@@ -25,14 +27,110 @@ namespace TrackerEnabledDbContext
 
         /// <summary>
         /// This method saves the model changes to the database.
-        /// If the tracker for of table is active, it will also put the old values in tracking table.
+        /// If the tracker for a table is active, it will also put the old values in tracking table.
         /// Always use this method instead of SaveChanges() whenever possible.
         /// </summary>
         /// <param name="userName">Username of the logged in identity</param>
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual int SaveChanges(object userName)
         {
-            return CommonTracker.SaveChanges(this, userName);
+            CommonTracker.AuditChanges(this, userName);
+
+            var addedEntries = CommonTracker.GetAdditions(this);
+            // Call the original SaveChanges(), which will save both the changes made and the audit records...Note that added entry auditing is still remaining.
+            int result = base.SaveChanges();
+            //By now., we have got the primary keys of added entries of added entiries because of the call to savechanges.
+
+            CommonTracker.AuditAdditions(this, userName, addedEntries);
+
+            //save changes to audit of added entries
+            base.SaveChanges();
+            return result;
+        }
+
+
+        /// <summary>
+        /// This method saves the model changes to the database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table.
+        /// </summary>
+        /// <param name="userName">Username of the logged in identity</param>
+        /// <returns>Returns the number of objects written to the underlying database.</returns>
+        public override int SaveChanges()
+        {
+            return this.SaveChanges(null);
+        }
+
+        /// <summary>
+        /// Asynchronously saves all changes made in this context to the underlying database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table.
+        /// </summary>
+        /// <param name="userName">Username of the logged in identity</param>
+        /// <param name="cancellationToken">
+        /// A System.Threading.CancellationToken to observe while waiting for the task
+        /// to complete.
+        /// </param>
+        /// <returns>Returns the number of objects written to the underlying database.</returns>
+        public async virtual Task<int> SaveChangesAsync(object userName, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested == true)
+                cancellationToken.ThrowIfCancellationRequested();
+
+            CommonTracker.AuditChanges(this, userName);
+
+            var addedEntries = CommonTracker.GetAdditions(this);
+
+            // Call the original SaveChanges(), which will save both the changes made and the audit records...Note that added entry auditing is still remaining.
+            int result = await base.SaveChangesAsync(cancellationToken);
+
+            //By now., we have got the primary keys of added entries of added entiries because of the call to savechanges.
+            CommonTracker.AuditAdditions(this, userName, addedEntries);
+
+            //save changes to audit of added entries
+            await base.SaveChangesAsync(cancellationToken);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Asynchronously saves all changes made in this context to the underlying database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table.
+        /// Always use this method instead of SaveChangesAsync() whenever possible.
+        /// </summary>
+        /// <param name="userName">Username of the logged in identity</param>
+        /// <returns>Returns the number of objects written to the underlying database.</returns>
+        public virtual Task<int> SaveChangesAsync(object userName)
+        {
+            return this.SaveChangesAsync(userName, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously saves all changes made in this context to the underlying database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table with null UserName.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous save operation.  The task result
+        /// contains the number of objects written to the underlying database.
+        /// </returns>
+        public override Task<int> SaveChangesAsync()
+        {
+            return this.SaveChangesAsync(null, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously saves all changes made in this context to the underlying database.
+        /// If the tracker for a table is active, it will also put the old values in tracking table with null UserName.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A System.Threading.CancellationToken to observe while waiting for the task
+        /// to complete.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous save operation.  The task result
+        /// contains the number of objects written to the underlying database.
+        /// </returns>
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken)
+        {
+            return this.SaveChangesAsync(cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #4. 

Marks SaveChanges as virtual on both contexts, so that they may be overridden.

Modified to log changes even if a userName isn't passed to SaveChanges. UserName entity property will default to null.

Added asynchronous support -- specifically SaveChangesAsync on both TrackerContext and TrackerIdentityContext.
