### PR TITLE
Avoid Execution of Database Queries When Creating AuditLogDetail

### DIFF
--- a/TrackerEnabledDbContext.Common/AddedLogDetailsAuditor.cs
+++ b/TrackerEnabledDbContext.Common/AddedLogDetailsAuditor.cs
@@ -1,0 +1,31 @@
+﻿using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
+using TrackerEnabledDbContext.Common.Models;
+
+namespace TrackerEnabledDbContext.Common
+{
+    /// <summary>
+    /// Creates AuditLogDetails for entries added in a previous call to SaveChanges.
+    /// </summary>
+    public class AddedLogDetailsAuditor : LogDetailsAuditor
+    {
+        public AddedLogDetailsAuditor(DbEntityEntry dbEntry, AuditLog log) : base(dbEntry, log)
+        {
+        }
+
+        /// <summary>
+        /// Treat unchanged entries as added entries when creating audit records.
+        /// </summary>
+        /// <param name="dbEntry"></param>
+        /// <returns></returns>
+        protected override EntityState StateOf(DbEntityEntry dbEntry)
+        {
+            if (dbEntry.State == EntityState.Unchanged)
+            {
+                return EntityState.Added;
+            }
+
+            return base.StateOf(dbEntry);
+        }
+    }
+}

--- a/TrackerEnabledDbContext.Common/LogAuditor.cs
+++ b/TrackerEnabledDbContext.Common/LogAuditor.cs
@@ -42,7 +42,9 @@ namespace TrackerEnabledDbContext.Common
                 RecordId = _dbEntry.GetPrimaryKeyValues(keyNames).ToString()
             };
 
-            using (var detailsAuditor = new LogDetailsAuditor(_dbEntry, newlog))
+            using (var detailsAuditor = (eventType == EventType.Added)
+                ? new AddedLogDetailsAuditor(_dbEntry, newlog)
+                : new LogDetailsAuditor(_dbEntry, newlog))
             {
                 newlog.LogDetails = detailsAuditor.CreateLogDetails().ToList();
             }

--- a/TrackerEnabledDbContext.Common/TrackerEnabledDbContext.Common.csproj
+++ b/TrackerEnabledDbContext.Common/TrackerEnabledDbContext.Common.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AddedLogDetailsAuditor.cs" />
     <Compile Include="Attributes\SkipTrackingAttribute.cs" />
     <Compile Include="Attributes\TrackChangesAttribute.cs" />
     <Compile Include="Extensions\DbEntityEntryExtensions.cs" />


### PR DESCRIPTION
This patch addresses the following issue: [Creation of AuditLogDetail Causes Execution of Multiple Database Queries](https://github.com/bilal-fazlani/tracker-enabled-dbcontext/issues/32)

This patch includes integration tests to check that LogDetailsAuditor no longer queries the database when creating a new AuditLogDetail record and changes to LogDetailsAuditor to implement this behaviour.