### PR TITLE
Bug Fix: check subtypes when determining table name to avoid crashing

### DIFF
--- a/TrackerEnabledDbContext.Common/Extensions/TypeExtensions.cs
+++ b/TrackerEnabledDbContext.Common/Extensions/TypeExtensions.cs
@@ -187,7 +187,7 @@ namespace TrackerEnabledDbContext.Common.Extensions
             string dbsetPropertyName =
                 context.GetType()
                     .GetProperties()
-                    .Single(x => x.PropertyType.GenericTypeArguments.Any(y => y == entityType))
+                    .Single(x => x.PropertyType.GenericTypeArguments.Any(y => y == entityType || entityType.IsSubclassOf(y)))
                     .Name;
 
             // Get table name (if it has a Table attribute, use that, otherwise dbset property name)


### PR DESCRIPTION
EF Tables can have multiple subclasses in the same table (using discriminator column to differentiate).  Currently when using auditing in this case, we crash.

So to account for this when determining table name, check if entityType is subclass of y as well.