### PR TITLE
TrackChanges for specific types of model events

### DIFF
--- a/TrackerEnabledDbContext.Common.Testing/Extensions/AuditAssertExtensions.cs
+++ b/TrackerEnabledDbContext.Common.Testing/Extensions/AuditAssertExtensions.cs
@@ -7,6 +7,14 @@ namespace TrackerEnabledDbContext.Common.Testing.Extensions
 {
     public static class AuditAssertExtensions
     {
+        public static T AssertNoAuditForAddition<T>(this T entity, ITrackerContext db, object entityId,
+            string userName = null, params KeyValuePair<string, string>[] newValues)
+        {
+            IEnumerable<AuditLog> logs = db.GetLogs<T>(entityId)
+                .AssertCount(0, "log count is not zero");
+
+            return entity;
+        }
         public static T AssertAuditForAddition<T>(this T entity, ITrackerContext db, object entityId,
             string userName = null, params KeyValuePair<string, string>[] newValues)
         {

--- a/TrackerEnabledDbContext.Common.Testing/ITestDbContext.cs
+++ b/TrackerEnabledDbContext.Common.Testing/ITestDbContext.cs
@@ -12,5 +12,6 @@ namespace TrackerEnabledDbContext.Common.Testing
         DbSet<ModelWithCompositeKey> ModelsWithCompositeKey { get; set; }
         DbSet<ModelWithConventionalKey> ModelsWithConventionalKey { get; set; }
         DbSet<ModelWithSkipTracking> ModelsWithSkipTracking { get; set; }
+        DbSet<ModelWithDeleteOnlyTracking> ModelsWithDeleteOnlyTracking { get; set; }
     }
 }

--- a/TrackerEnabledDbContext.Common.Testing/Models/ModelWithDeleteOnlyTracking.cs
+++ b/TrackerEnabledDbContext.Common.Testing/Models/ModelWithDeleteOnlyTracking.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using TrackerEnabledDbContext.Common.Models;
+
+namespace TrackerEnabledDbContext.Common.Testing.Models
+{
+    [TrackChanges(true, new [] { EventType.Deleted })]
+    public class ModelWithDeleteOnlyTracking
+    {
+        public int Id { get; set; }
+        public Guid TrackedProperty { get; set; }
+
+        [SkipTracking]
+        public string UnTrackedProperty { get; set; }
+    }
+}

--- a/TrackerEnabledDbContext.Common.Testing/TrackerEnabledDbContext.Common.Testing.csproj
+++ b/TrackerEnabledDbContext.Common.Testing/TrackerEnabledDbContext.Common.Testing.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Models\ChildModel.cs" />
     <Compile Include="Models\ModelWithCompositeKey.cs" />
     <Compile Include="Models\ModelWithConventionalKey.cs" />
+    <Compile Include="Models\ModelWithDeleteOnlyTracking.cs" />
     <Compile Include="Models\ModelWithSkipTracking.cs" />
     <Compile Include="Models\NormalModel.cs" />
     <Compile Include="Models\ParentModel.cs" />

--- a/TrackerEnabledDbContext.Common/Attributes/TrackChangesAttribute.cs
+++ b/TrackerEnabledDbContext.Common/Attributes/TrackChangesAttribute.cs
@@ -1,5 +1,8 @@
 ﻿// ReSharper disable once CheckNamespace
 
+using System.Collections;
+using System.Collections.Generic;
+using TrackerEnabledDbContext.Common.Models;
 namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
@@ -9,11 +12,18 @@ namespace System.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public class TrackChangesAttribute : Attribute
     {
-        public TrackChangesAttribute(bool trackChnages = true)
+        public TrackChangesAttribute(bool trackChnages = true, object changeTypes = null)
         {
             Enabled = trackChnages;
+
+            if (changeTypes != null && changeTypes is IEnumerable)
+            {
+                ChangeTypes = ((IEnumerable<EventType>)changeTypes);
+            }
         }
 
         public bool Enabled { get; set; }
+
+        public IEnumerable<EventType> ChangeTypes { get; set; }
     }
 }

--- a/TrackerEnabledDbContext.Common/LogAuditor.cs
+++ b/TrackerEnabledDbContext.Common/LogAuditor.cs
@@ -26,7 +26,7 @@ namespace TrackerEnabledDbContext.Common
             Type entityType = _dbEntry.Entity.GetType().GetEntityType();
             DateTime changeTime = DateTime.UtcNow;
 
-            if (!entityType.IsTrackingEnabled())
+            if (!entityType.IsTrackingEnabled(eventType))
             {
                 return null;
             }

--- a/TrackerEnabledDbContext.Identity.IntegrationTests/TestTrackerIdentityContext .cs
+++ b/TrackerEnabledDbContext.Identity.IntegrationTests/TestTrackerIdentityContext .cs
@@ -18,5 +18,6 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
         public DbSet<ModelWithCompositeKey> ModelsWithCompositeKey { get; set; }
         public DbSet<ModelWithConventionalKey> ModelsWithConventionalKey { get; set; }
         public DbSet<ModelWithSkipTracking> ModelsWithSkipTracking { get; set; }
+        public DbSet<ModelWithDeleteOnlyTracking> ModelsWithDeleteOnlyTracking { get; set; }
     }
 }

--- a/TrackerEnabledDbContext.Identity.IntegrationTests/TrackerIdentityContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.Identity.IntegrationTests/TrackerIdentityContextIntegrationTests.cs
@@ -257,6 +257,33 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
         }
 
         [TestMethod]
+        public void Can_skip_tracking_of_adds_but_should_track_deletes()
+        {
+            string username = RandomText;
+
+            //add enitties
+            var entity = new ModelWithDeleteOnlyTracking { TrackedProperty = Guid.NewGuid(), UnTrackedProperty = RandomText };
+            db.ModelsWithDeleteOnlyTracking.Add(entity);
+            db.SaveChanges(username);
+
+            //assert enity added
+            entity.Id.AssertIsNotZero();
+
+            // assert no audit for addition
+            entity.AssertNoAuditForAddition(db, entity.Id, username, null);
+
+            //remove
+            db.Entry(entity).State = EntityState.Deleted;
+            db.SaveChanges(username);
+
+            //assert deletion
+            entity.AssertAuditForDeletion(db, entity.Id, username,
+                new KeyValuePair<string, string>("TrackedProperty", entity.TrackedProperty.ToString()),
+                new KeyValuePair<string, string>("Id", entity.Id.ToString(CultureInfo.InvariantCulture))
+                );
+        }
+
+        [TestMethod]
         public void Can_track_composite_keys()
         {
             string key1 = RandomText;

--- a/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
@@ -17,5 +17,6 @@ namespace TrackerEnabledDbContext.IntegrationTests
         public DbSet<ModelWithCompositeKey> ModelsWithCompositeKey { get; set; }
         public DbSet<ModelWithConventionalKey> ModelsWithConventionalKey { get; set; }
         public DbSet<ModelWithSkipTracking> ModelsWithSkipTracking { get; set; }
+        public DbSet<ModelWithDeleteOnlyTracking> ModelsWithDeleteOnlyTracking { get; set; }
     }
 }


### PR DESCRIPTION
Adding support to TrackChanges only for specific types of events on a modal.  For example, you could add TrackChanges for "Deleted" only and ignore "Added" or "Modified".  

This change came specifically out of a use case in which I needed a way to archive records when they were deleted, but didn't need all the log data upon creation/modification.