### PR TITLE
Add GetLastAuditLogId function

### DIFF
--- a/TrackerEnabledDbContext.Common/CommonTracker.cs
+++ b/TrackerEnabledDbContext.Common/CommonTracker.cs
@@ -97,5 +97,17 @@ namespace TrackerEnabledDbContext.Common
             string key = primaryKey.ToString();
             return context.AuditLog.Where(x => x.TableName == tableName && x.RecordId == key);
         }
+
+        /// <summary>
+        ///     Get the id of the most recently created log for the given table name for a specific record
+        /// </summary>
+        /// <param name="tableName">table name</param>
+        /// <param name="primaryKey">primary key of record</param>
+        /// <returns>Log id</returns>
+        public static int GetLastAuditLogId(ITrackerContext context, string tableName, object primaryKey)
+        {
+            string key = primaryKey.ToString();
+            return context.AuditLog.Where(x => x.TableName == tableName && x.RecordId == key).OrderByDescending(x => x.AuditLogId).Select(x => x.AuditLogId).FirstOrDefault();
+        }
     }
 }

--- a/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
+++ b/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
@@ -114,6 +114,17 @@ namespace TrackerEnabledDbContext.Identity
             return CommonTracker.GetLogs(this, tableName, primaryKey);
         }
 
+        /// <summary>
+        ///     Get the id of the most recently created log for the given table name for a specific record
+        /// </summary>
+        /// <param name="tableName">table name</param>
+        /// <param name="primaryKey">primary key of record</param>
+        /// <returns>Log id</returns>
+        public int GetLastAuditLogId(string tableName, object primaryKey)
+        {
+            return CommonTracker.GetLastAuditLogId(this, tableName, primaryKey);
+        }
+
         #region -- Async --
 
         /// <summary>

--- a/TrackerEnabledDbContext/TrackerContext.cs
+++ b/TrackerEnabledDbContext/TrackerContext.cs
@@ -106,6 +106,17 @@ namespace TrackerEnabledDbContext
             return CommonTracker.GetLogs(this, tableName, primaryKey);
         }
 
+        /// <summary>
+        ///     Get the id of the most recently created log for the given table name for a specific record
+        /// </summary>
+        /// <param name="tableName">table name</param>
+        /// <param name="primaryKey">primary key of record</param>
+        /// <returns>Log id</returns>
+        public int GetLastAuditLogId(string tableName, object primaryKey)
+        {
+            return CommonTracker.GetLastAuditLogId(this, tableName, primaryKey);
+        }
+
         #region -- Async --
 
         /// <summary>


### PR DESCRIPTION
Add GetLastAuditLogId function to get the id of the most recently created log for the given table name for a specific record. 

Typical usage of this would be to when inserting a newly created audit id along with a copy of a modified record into a history table. If you wanted to provide a way of viewing record state at the time the audit log was created.
