### PR TITLE
Changed from table based to entity based audit tracking allowing rebuild of old objects

### DIFF
--- a/SampleLogMaker/Controllers/HistoryController.cs
+++ b/SampleLogMaker/Controllers/HistoryController.cs
@@ -37,9 +37,9 @@ namespace SampleLogMaker.Controllers
                             Date = log.EventDateUTC.ToLocalTime().DateTime,
                             LogId = log.AuditLogId,
                             RecordId = log.RecordId,
-                            TableName = log.TableName,
+                            TypeFullName = log.TypeFullName,
                             UserName = log.UserName,
-                            Details = log.LogDetails.Select(x => new LogDetail { PropertyName = x.ColumnName, NewValue = x.NewValue })
+                            Details = log.LogDetails.Select(x => new LogDetail { PropertyName = x.PropertyName, NewValue = x.NewValue })
                         });
                         break;
 
@@ -49,20 +49,20 @@ namespace SampleLogMaker.Controllers
                             Date = log.EventDateUTC.ToLocalTime().DateTime,
                             LogId = log.AuditLogId,
                             RecordId = log.RecordId,
-                            TableName = log.TableName,
+                            TypeFullName = log.TypeFullName,
                             UserName = log.UserName,
-                            Details = log.LogDetails.Select(x => new LogDetail { PropertyName = x.ColumnName, OldValue = x.OriginalValue })
+                            Details = log.LogDetails.Select(x => new LogDetail { PropertyName = x.PropertyName, OldValue = x.OriginalValue })
                         });
                         break;
 
                     case EventType.Modified: //modified
                         vm.Add(new ChangedHistoryVM
                         {
-                            Details = log.LogDetails.Select(x => new LogDetail { PropertyName = x.ColumnName, NewValue = x.NewValue, OldValue = x.OriginalValue }),
+                            Details = log.LogDetails.Select(x => new LogDetail { PropertyName = x.PropertyName, NewValue = x.NewValue, OldValue = x.OriginalValue }),
                             Date = log.EventDateUTC.ToLocalTime().DateTime,
                             LogId = log.AuditLogId,
                             RecordId = log.RecordId,
-                            TableName = log.TableName,
+                            TypeFullName = log.TypeFullName,
                             UserName = log.UserName,
                         });
                         break;

--- a/SampleLogMaker/ViewModels/History.cs
+++ b/SampleLogMaker/ViewModels/History.cs
@@ -18,7 +18,7 @@ namespace SampleLogMaker.ViewModels
 
         public string UserName { get; set; }
 
-        public string TableName { get; set; }
+        public string TypeFullName { get; set; }
 
         public IEnumerable<LogDetail> Details = new List<LogDetail>();
     }

--- a/TrackerEnabledDbContext.Common.Testing/Extensions/AuditAssertExtensions.cs
+++ b/TrackerEnabledDbContext.Common.Testing/Extensions/AuditAssertExtensions.cs
@@ -23,7 +23,7 @@ namespace TrackerEnabledDbContext.Common.Testing.Extensions
             foreach (var keyValuePair in newValues)
             {
                 lastLog.LogDetails.AssertAny(x => x.NewValue == keyValuePair.Value
-                                                  && x.ColumnName == keyValuePair.Key);
+                                                  && x.PropertyName == keyValuePair.Key);
             }
 
             return entity;
@@ -45,7 +45,7 @@ namespace TrackerEnabledDbContext.Common.Testing.Extensions
             foreach (var keyValuePair in oldValues)
             {
                 lastLog.LogDetails.AssertAny(x => x.OriginalValue == keyValuePair.Value
-                                                  && x.ColumnName == keyValuePair.Key);
+                                                  && x.PropertyName == keyValuePair.Key);
             }
 
             return entity;
@@ -68,7 +68,7 @@ namespace TrackerEnabledDbContext.Common.Testing.Extensions
             foreach (AuditLogDetail logdetail in logdetails)
             {
                 lastLog.LogDetails.AssertAny(x => x.OriginalValue == logdetail.OriginalValue
-                                                  && x.ColumnName == logdetail.ColumnName
+                                                  && x.PropertyName == logdetail.PropertyName
                                                   && x.NewValue == logdetail.NewValue,
                     "could not find an expected auditlog detail");
             }

--- a/TrackerEnabledDbContext.Common/Attributes/TrackChangesAttribute.cs
+++ b/TrackerEnabledDbContext.Common/Attributes/TrackChangesAttribute.cs
@@ -6,12 +6,12 @@ namespace System.ComponentModel.DataAnnotations
     ///     Enables tracking of Entity tables.
     ///     Place this attribute on a entity class which you want to track for audit.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class TrackChangesAttribute : Attribute
     {
-        public TrackChangesAttribute(bool trackChnages = true)
+        public TrackChangesAttribute(bool trackChanges = true)
         {
-            Enabled = trackChnages;
+            Enabled = trackChanges;
         }
 
         public bool Enabled { get; set; }

--- a/TrackerEnabledDbContext.Common/CommonTracker.cs
+++ b/TrackerEnabledDbContext.Common/CommonTracker.cs
@@ -100,7 +100,7 @@ namespace TrackerEnabledDbContext.Common
         }
 
         /// <summary>
-        ///     Get all logs for the given table name for a specific record
+        ///     Get all logs for the given entity name for a specific record
         /// </summary>
         /// <param name="entityTypeName">entity type name</param>
         /// <param name="primaryKey">primary key of record</param>

--- a/TrackerEnabledDbContext.Common/CommonTracker.cs
+++ b/TrackerEnabledDbContext.Common/CommonTracker.cs
@@ -54,12 +54,10 @@ namespace TrackerEnabledDbContext.Common
         }
 
 
-
-
         private static IEnumerable<string> EntityTypeNames<TEntity>()
         {
             Type entityType = typeof(TEntity);
-            return typeof(TEntity).Assembly.GetTypes().Where(type => type.IsSubclassOf(entityType) || type.Name == entityType.Name).Select(m => m.FullName);
+            return typeof(TEntity).Assembly.GetTypes().Where(t => t.IsSubclassOf(entityType) || t.FullName == entityType.FullName).Select(m => m.FullName);
         }
 
         /// <summary>

--- a/TrackerEnabledDbContext.Common/CommonTracker.cs
+++ b/TrackerEnabledDbContext.Common/CommonTracker.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
@@ -52,50 +53,62 @@ namespace TrackerEnabledDbContext.Common
             }
         }
 
-        /// <summary>
-        ///     Get all logs for the given model type
-        /// </summary>
-        /// <typeparam name="TTable">Type of domain model</typeparam>
-        /// <returns></returns>
-        public static IQueryable<AuditLog> GetLogs<TTable>(ITrackerContext context)
+
+
+
+        private static IEnumerable<string> EntityTypeNames<TEntity>()
         {
-            string tableName = typeof (TTable).GetTableName(context);
-            return context.AuditLog.Where(x => x.TableName == tableName);
+            Type entityType = typeof(TEntity);
+            return typeof(TEntity).Assembly.GetTypes().Where(type => type.IsSubclassOf(entityType) || type.Name == entityType.Name).Select(m => m.FullName);
         }
 
         /// <summary>
-        ///     Get all logs for the given table name
+        ///     Get all logs for the given model type
         /// </summary>
-        /// <param name="tableName">Name of table</param>
+        /// <typeparam name="TEntity">Type of domain model</typeparam>
         /// <returns></returns>
-        public static IQueryable<AuditLog> GetLogs(ITrackerContext context, string tableName)
+        public static IQueryable<AuditLog> GetLogs<TEntity>(ITrackerContext context)
         {
-            return context.AuditLog.Where(x => x.TableName == tableName);
+            IEnumerable<string> entityTypeNames = EntityTypeNames<TEntity>();
+            string entityTypeName = typeof(TEntity).Name;
+            return context.AuditLog.Where(x => entityTypeNames.Contains(x.TypeFullName));
+        }
+
+        /// <summary>
+        ///     Get all logs for the enitity type name
+        /// </summary>
+        /// <param name="entityTypeName">Name of entity type</param>
+        /// <returns></returns>
+        public static IQueryable<AuditLog> GetLogs(ITrackerContext context, string entityTypeName)
+        {
+            return context.AuditLog.Where(x => x.TypeFullName == entityTypeName);
         }
 
         /// <summary>
         ///     Get all logs for the given model type for a specific record
         /// </summary>
-        /// <typeparam name="TTable">Type of domain model</typeparam>
+        /// <typeparam name="TEntity">Type of domain model</typeparam>
         /// <param name="primaryKey">primary key of record</param>
         /// <returns></returns>
-        public static IQueryable<AuditLog> GetLogs<TTable>(ITrackerContext context, object primaryKey)
+        public static IQueryable<AuditLog> GetLogs<TEntity>(ITrackerContext context, object primaryKey)
         {
             string key = primaryKey.ToString();
-            string tableName = typeof (TTable).GetTableName(context);
-            return context.AuditLog.Where(x => x.TableName == tableName && x.RecordId == key);
+            string entityTypeName = typeof(TEntity).Name;
+            IEnumerable<string> entityTypeNames = EntityTypeNames<TEntity>();
+
+            return context.AuditLog.Where(x => entityTypeNames.Contains(x.TypeFullName) && x.RecordId == key);
         }
 
         /// <summary>
         ///     Get all logs for the given table name for a specific record
         /// </summary>
-        /// <param name="tableName">table name</param>
+        /// <param name="entityTypeName">entity type name</param>
         /// <param name="primaryKey">primary key of record</param>
         /// <returns></returns>
-        public static IQueryable<AuditLog> GetLogs(ITrackerContext context, string tableName, object primaryKey)
+        public static IQueryable<AuditLog> GetLogs(ITrackerContext context, string entityTypeName, object primaryKey)
         {
             string key = primaryKey.ToString();
-            return context.AuditLog.Where(x => x.TableName == tableName && x.RecordId == key);
+            return context.AuditLog.Where(x => x.TypeFullName == entityTypeName && x.RecordId == key);
         }
     }
 }

--- a/TrackerEnabledDbContext.Common/Extensions/TypeExtensions.cs
+++ b/TrackerEnabledDbContext.Common/Extensions/TypeExtensions.cs
@@ -117,12 +117,6 @@ namespace TrackerEnabledDbContext.Common.Extensions
             return GetFromCache(ColumnTrackerCache, key, k => ColumnTrackerIndicatorFactory(type, propertyName));
         }
 
-        //public static string GetTableName(this Type entityType, ITrackerContext context)
-        //{
-        //    string key = entityType.FullName;
-        //    return GetFromCache(TableNameCache, key, k => TableNameFactory(entityType, context));
-        //}
-
         public static string GetPropertyName(this Type type, string propertyName)
         {
             string key = GetFullPropertyName(type, propertyName);

--- a/TrackerEnabledDbContext.Common/LogAuditor.cs
+++ b/TrackerEnabledDbContext.Common/LogAuditor.cs
@@ -38,7 +38,7 @@ namespace TrackerEnabledDbContext.Common
                 UserName = userName != null ? userName.ToString() : null,
                 EventDateUTC = changeTime,
                 EventType = eventType,
-                TableName = entityType.GetTableName(context),
+                TypeFullName = entityType.FullName,
                 RecordId = _dbEntry.GetPrimaryKeyValues(keyNames).ToString()
             };
 

--- a/TrackerEnabledDbContext.Common/LogDetailsAuditor.cs
+++ b/TrackerEnabledDbContext.Common/LogDetailsAuditor.cs
@@ -32,7 +32,7 @@ namespace TrackerEnabledDbContext.Common
                 {
                     yield return new AuditLogDetail
                     {
-                        ColumnName = type.GetColumnName(propertyName),
+                        PropertyName = type.GetPropertyName(propertyName),
                         OriginalValue = OriginalValue(propertyName),
                         NewValue = CurrentValue(propertyName),
                         Log = _log

--- a/TrackerEnabledDbContext.Common/Models/AuditLog.cs
+++ b/TrackerEnabledDbContext.Common/Models/AuditLog.cs
@@ -31,7 +31,7 @@ namespace TrackerEnabledDbContext.Common.Models
 
         [Required]
         [MaxLength(256)]
-        public string TableName { get; set; }
+        public string TypeFullName { get; set; }
 
         [Required]
         [MaxLength(256)]

--- a/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
+++ b/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
@@ -10,7 +10,7 @@ namespace TrackerEnabledDbContext.Common.Models
 
         [Required]
         [MaxLength(256)]
-        public string ColumnName { get; set; }
+        public string PropertyName { get; set; }
 
         public string OriginalValue { get; set; }
 

--- a/TrackerEnabledDbContext.Identity.IntegrationTests/TrackerIdentityContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.Identity.IntegrationTests/TrackerIdentityContextIntegrationTests.cs
@@ -190,7 +190,7 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
                 {
                     NewValue = newDescription,
                     OriginalValue = oldDescription,
-                    ColumnName = "Description"
+                    PropertyName = "Description"
                 }
             }.ToArray();
 
@@ -228,7 +228,7 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
                 {
                     NewValue = parent2.Id.ToString(),
                     OriginalValue = parent1.Id.ToString(),
-                    ColumnName = "ParentId"
+                    PropertyName = "ParentId"
                 }
             }.ToArray();
 
@@ -367,7 +367,7 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
                 {
                     NewValue = newDescription,
                     OriginalValue = oldDescription,
-                    ColumnName = "Description"
+                    PropertyName = "Description"
                 }
             }.ToArray();
 

--- a/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
@@ -191,7 +191,7 @@ namespace TrackerEnabledDbContext.IntegrationTests
                 {
                     NewValue = newDescription,
                     OriginalValue = oldDescription,
-                    ColumnName = "Description"
+                    PropertyName = "Description"
                 }
             }.ToArray();
 
@@ -229,7 +229,7 @@ namespace TrackerEnabledDbContext.IntegrationTests
                 {
                     NewValue = parent2.Id.ToString(),
                     OriginalValue = parent1.Id.ToString(),
-                    ColumnName = "ParentId"
+                    PropertyName = "ParentId"
                 }
             }.ToArray();
 
@@ -368,7 +368,7 @@ namespace TrackerEnabledDbContext.IntegrationTests
                 {
                     NewValue = newDescription,
                     OriginalValue = oldDescription,
-                    ColumnName = "Description"
+                    PropertyName = "Description"
                 }
             }.ToArray();
 

--- a/TrackerEnabledDbContext/TrackerContext.cs
+++ b/TrackerEnabledDbContext/TrackerContext.cs
@@ -33,7 +33,7 @@ namespace TrackerEnabledDbContext
 
         /// <summary>
         ///     This method saves the model changes to the database.
-        ///     If the tracker for a table is active, it will also put the old values in tracking table.
+        ///     If the tracker for an entity is active, it will also put the old values in tracking table.
         ///     Always use this method instead of SaveChanges() whenever possible.
         /// </summary>
         /// <param name="userName">Username of the logged in identity</param>
@@ -56,7 +56,7 @@ namespace TrackerEnabledDbContext
 
         /// <summary>
         ///     This method saves the model changes to the database.
-        ///     If the tracker for a table is active, it will also put the old values in tracking table.
+        ///     If the tracker for an entity is active, it will also put the old values in tracking table.
         /// </summary>
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public override int SaveChanges()
@@ -75,13 +75,13 @@ namespace TrackerEnabledDbContext
         }
 
         /// <summary>
-        ///     Get all logs for the given table name
+        ///     Get all logs for the given entity name
         /// </summary>
-        /// <param name="tableName">Name of table</param>
+        /// <param name="entityName">full name of entity</param>
         /// <returns></returns>
-        public IQueryable<AuditLog> GetLogs(string tableName)
+        public IQueryable<AuditLog> GetLogs(string entityName)
         {
-            return CommonTracker.GetLogs(this, tableName);
+            return CommonTracker.GetLogs(this, entityName);
         }
 
         /// <summary>
@@ -96,21 +96,21 @@ namespace TrackerEnabledDbContext
         }
 
         /// <summary>
-        ///     Get all logs for the given table name for a specific record
+        ///     Get all logs for the given entity name for a specific record
         /// </summary>
-        /// <param name="tableName">table name</param>
+        /// <param name="entityName">full name of entity</param>
         /// <param name="primaryKey">primary key of record</param>
         /// <returns></returns>
-        public IQueryable<AuditLog> GetLogs(string tableName, object primaryKey)
+        public IQueryable<AuditLog> GetLogs(string entityName, object primaryKey)
         {
-            return CommonTracker.GetLogs(this, tableName, primaryKey);
+            return CommonTracker.GetLogs(this, entityName, primaryKey);
         }
 
         #region -- Async --
 
         /// <summary>
         ///     Asynchronously saves all changes made in this context to the underlying database.
-        ///     If the tracker for a table is active, it will also put the old values in tracking table.
+        ///     If the tracker for an entity is active, it will also put the old values in tracking table.
         /// </summary>
         /// <param name="userName">Username of the logged in identity</param>
         /// <param name="cancellationToken">
@@ -141,7 +141,7 @@ namespace TrackerEnabledDbContext
 
         /// <summary>
         ///     Asynchronously saves all changes made in this context to the underlying database.
-        ///     If the tracker for a table is active, it will also put the old values in tracking table.
+        ///     If the tracker for an entity is active, it will also put the old values in tracking table.
         ///     Always use this method instead of SaveChangesAsync() whenever possible.
         /// </summary>
         /// <returns>Returns the number of objects written to the underlying database.</returns>
@@ -152,7 +152,7 @@ namespace TrackerEnabledDbContext
 
         /// <summary>
         ///     Asynchronously saves all changes made in this context to the underlying database.
-        ///     If the tracker for a table is active, it will also put the old values in tracking table.
+        ///     If the tracker for an entity is active, it will also put the old values in tracking table.
         ///     Always use this method instead of SaveChangesAsync() whenever possible.
         /// </summary>
         /// <returns>Returns the number of objects written to the underlying database.</returns>
@@ -163,7 +163,7 @@ namespace TrackerEnabledDbContext
 
         /// <summary>
         ///     Asynchronously saves all changes made in this context to the underlying database.
-        ///     If the tracker for a table is active, it will also put the old values in tracking table with null UserName.
+        ///     If the tracker for an entity is active, it will also put the old values in tracking table with null UserName.
         /// </summary>
         /// <returns>
         ///     A task that represents the asynchronous save operation.  The task result
@@ -176,7 +176,7 @@ namespace TrackerEnabledDbContext
 
         /// <summary>
         ///     Asynchronously saves all changes made in this context to the underlying database.
-        ///     If the tracker for a table is active, it will also put the old values in tracking table with null UserName.
+        ///     If the tracker for an entity is active, it will also put the old values in tracking table with null UserName.
         /// </summary>
         /// <param name="cancellationToken">
         ///     A System.Threading.CancellationToken to observe while waiting for the task


### PR DESCRIPTION
In keeping with the spirit of EF we shouldn't concern ourselves with which underlying table a record was edited from, but the entity itself.  Instead of the name of the DbSet being stored in the table we save the concrete class full name.  This way the object can be reconstructed and found by types.  This is not possible if you use the DbSet's name.

This update also allows a class to have the TrackChangesAttribute applied and all sub classes also tracked.  You can then use context.GetLogs\<T\>() and the Activator class to rebuild the set of possibly different concrete objects at any given point in time.




These changes also fix a bug introduced in the most recent pull request merged at commit 6d4304be77ba7f39761fc3124de92eb480c0c220 as the TableNameFactory is no longer needed, we simply use the Object.FullName property.

Previous TableNameFactory bug:
In the event that sub classes have their own DbSet<> object the line changed in the recent merge will throw a "sequence contains more than one element..." exception

Class A
Class B : A

DbContext : TrackerContext {
    DbSet\<A\> setOfAllAs
    DbSet\<B\> setOfAllBs
}

with the above classes and with a TPH database the Discriminator column could contain A or B but these types cannot be determined by the current values in TableName column