### PR TITLE
fix unit test to get logs by entity full name

### DIFF
--- a/TrackerEnabledDbContext.Identity.IntegrationTests/TrackerIdentityContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.Identity.IntegrationTests/TrackerIdentityContextIntegrationTests.cs
@@ -293,7 +293,7 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
             await db.SaveChangesAsync(CancellationToken.None);
             model.Id.AssertIsNotZero();
 
-            IEnumerable<AuditLog> logs = db.GetLogs("NormalModels", model.Id)
+            IEnumerable<AuditLog> logs = db.GetLogs("TrackerEnabledDbContext.Common.Testing.Models.NormalModel", model.Id)
                 .AssertCountIsNotZero("logs not found");
 
             AuditLog lastLog = logs.LastOrDefault().AssertIsNotNull("last log is null");
@@ -335,7 +335,7 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
             await db.SaveChangesAsync(RandomText);
             model.Id.AssertIsNotZero();
 
-            IEnumerable<AuditLog> logs = db.GetLogs("NormalModels")
+            IEnumerable<AuditLog> logs = db.GetLogs("TrackerEnabledDbContext.Common.Testing.Models.NormalModel")
                 .AssertCountIsNotZero("logs not found");
 
             AuditLog lastLog = logs.LastOrDefault().AssertIsNotNull("last log is null");

--- a/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
@@ -294,7 +294,7 @@ namespace TrackerEnabledDbContext.IntegrationTests
             await db.SaveChangesAsync(CancellationToken.None);
             model.Id.AssertIsNotZero();
 
-            IEnumerable<AuditLog> logs = db.GetLogs("NormalModels", model.Id)
+            IEnumerable<AuditLog> logs = db.GetLogs("TrackerEnabledDbContext.Common.Testing.Models.NormalModel", model.Id)
                 .AssertCountIsNotZero("logs not found");
 
             AuditLog lastLog = logs.LastOrDefault().AssertIsNotNull("last log is null");
@@ -336,7 +336,7 @@ namespace TrackerEnabledDbContext.IntegrationTests
             await db.SaveChangesAsync(RandomText);
             model.Id.AssertIsNotZero();
 
-            IEnumerable<AuditLog> logs = db.GetLogs("NormalModels")
+            IEnumerable<AuditLog> logs = db.GetLogs("TrackerEnabledDbContext.Common.Testing.Models.NormalModel")
                 .AssertCountIsNotZero("logs not found");
 
             AuditLog lastLog = logs.LastOrDefault().AssertIsNotNull("last log is null");


### PR DESCRIPTION
All unit tests pass with the updated GetLogs parameters to use the entity full name instead of the old derived table name