### PR TITLE
Updated Audit entities keys to long instead of int

### DIFF
--- a/SampleLogMaker/ViewModels/History.cs
+++ b/SampleLogMaker/ViewModels/History.cs
@@ -7,7 +7,7 @@ namespace SampleLogMaker.ViewModels
 {
     public class BaseHistoryVM
     {
-        public Guid LogId { get; set; }
+        public long LogId { get; set; }
         
         /// <summary>
         /// This is a strign now as it can be a composite key. This may be changed to array/collection later.

--- a/SampleLogMaker/ViewModels/History.cs
+++ b/SampleLogMaker/ViewModels/History.cs
@@ -7,7 +7,7 @@ namespace SampleLogMaker.ViewModels
 {
     public class BaseHistoryVM
     {
-        public int LogId { get; set; }
+        public Guid LogId { get; set; }
         
         /// <summary>
         /// This is a strign now as it can be a composite key. This may be changed to array/collection later.

--- a/TrackerEnabledDbContext.Common/Models/AuditLog.cs
+++ b/TrackerEnabledDbContext.Common/Models/AuditLog.cs
@@ -19,7 +19,7 @@ namespace TrackerEnabledDbContext.Common.Models
 
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public int AuditLogId { get; set; }
+        public Guid AuditLogId { get; set; }
 
         public string UserName { get; set; }
 

--- a/TrackerEnabledDbContext.Common/Models/AuditLog.cs
+++ b/TrackerEnabledDbContext.Common/Models/AuditLog.cs
@@ -19,7 +19,7 @@ namespace TrackerEnabledDbContext.Common.Models
 
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public Guid AuditLogId { get; set; }
+        public long AuditLogId { get; set; }
 
         public string UserName { get; set; }
 

--- a/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
+++ b/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
@@ -3,10 +3,13 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TrackerEnabledDbContext.Common.Models
 {
+    using System;
+
     public class AuditLogDetail
     {
         [Key]
-        public int Id { get; set; }
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public Guid Id { get; set; }
 
         [Required]
         [MaxLength(256)]

--- a/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
+++ b/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
@@ -19,7 +19,7 @@ namespace TrackerEnabledDbContext.Common.Models
 
         public string NewValue { get; set; }
 
-        public virtual int AuditLogId { get; set; }
+        public virtual Guid AuditLogId { get; set; }
 
         [ForeignKey("AuditLogId")]
         public virtual AuditLog Log { get; set; }

--- a/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
+++ b/TrackerEnabledDbContext.Common/Models/AuditLogDetail.cs
@@ -9,7 +9,7 @@ namespace TrackerEnabledDbContext.Common.Models
     {
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public Guid Id { get; set; }
+        public long Id { get; set; }
 
         [Required]
         [MaxLength(256)]
@@ -19,7 +19,7 @@ namespace TrackerEnabledDbContext.Common.Models
 
         public string NewValue { get; set; }
 
-        public virtual Guid AuditLogId { get; set; }
+        public virtual long AuditLogId { get; set; }
 
         [ForeignKey("AuditLogId")]
         public virtual AuditLog Log { get; set; }


### PR DESCRIPTION
Depending on level of use and size of database, running out of int values for the audit tables is a distinct possibility. I want to integrate this with an application where we have a 7 year data/log retention period, so running out of keys is highly likely and a risk I cannot assume, but still think this library is a good option.