### PR TITLE
Soft delete

### DIFF
--- a/TrackerEnabledDbContext.Common/CommonTracker.cs
+++ b/TrackerEnabledDbContext.Common/CommonTracker.cs
@@ -25,6 +25,14 @@ namespace TrackerEnabledDbContext.Common
                         ent.State == EntityState.Modified ? EventType.Modified : EventType.Deleted, dbContext);
                     if (record != null)
                     {
+                        if (ent.Entity is ISoftDelete && ent.State == EntityState.Deleted)
+                        {
+                            ent.State = EntityState.Unchanged;
+                            var entity = (ISoftDelete)ent.Entity;
+                            entity.IsDeleted = true;
+                            ent.State = EntityState.Modified;
+                        }
+
                         dbContext.AuditLog.Add(record);
                     }
                 }

--- a/TrackerEnabledDbContext.Common/Interfaces/ISoftDelete.cs
+++ b/TrackerEnabledDbContext.Common/Interfaces/ISoftDelete.cs
@@ -1,0 +1,8 @@
+﻿
+namespace TrackerEnabledDbContext.Common.Interfaces
+{
+    public interface ISoftDelete
+    {
+        bool IsDeleted { get; set; }
+    }
+}

--- a/TrackerEnabledDbContext.Common/TrackerEnabledDbContext.Common.csproj
+++ b/TrackerEnabledDbContext.Common/TrackerEnabledDbContext.Common.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Fluent\TrackerColumnConfigurator.cs" />
     <Compile Include="Fluent\TrackerConfiguration.cs" />
     <Compile Include="Interfaces\IDbContext.cs" />
+    <Compile Include="Interfaces\ISoftDelete.cs" />
     <Compile Include="Interfaces\ITrackerContext.cs" />
     <Compile Include="LogAuditor.cs" />
     <Compile Include="LogDetailsAuditor.cs" />


### PR DESCRIPTION
Any model that implements ISoftDelete will soft delete records instead of hard deleting records. These records will still show up as a deleted event in the audit tracker