### PR TITLE
modified GetLogs(context, string) to include a third parameter 'inclu…

### DIFF
--- a/TrackerEnabledDbContext.Common/Interfaces/ITrackerContext.cs
+++ b/TrackerEnabledDbContext.Common/Interfaces/ITrackerContext.cs
@@ -6,12 +6,15 @@ using TrackerEnabledDbContext.Common.Models;
 
 namespace TrackerEnabledDbContext.Common.Interfaces
 {
+    using System;
+    using System.Linq.Expressions;
+
     public interface ITrackerContext : IDbContext
     {
         DbSet<AuditLog> AuditLog { get; set; }
         DbSet<AuditLogDetail> LogDetails { get; set; }
 
-        IQueryable<AuditLog> GetLogs(string tableName);
+        IQueryable<AuditLog> GetLogs(string entityName, params Expression<Func<AuditLog, object>>[] includeExpressions);
         IQueryable<AuditLog> GetLogs(string tableName, object primaryKey);
         IQueryable<AuditLog> GetLogs<TTable>();
         IQueryable<AuditLog> GetLogs<TTable>(object primaryKey);

--- a/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
+++ b/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
@@ -12,7 +12,9 @@ using TrackerEnabledDbContext.Common.Models;
 
 namespace TrackerEnabledDbContext.Identity
 {
+    using System;
     using System.Data.Common;
+    using System.Linq.Expressions;
 
     public class TrackerIdentityContext<TUser, TRole, TKey, TUserLogin, TUserRole, TUserClaim> :
         IdentityDbContext<TUser, TRole, TKey, TUserLogin, TUserRole, TUserClaim>, ITrackerContext
@@ -108,9 +110,9 @@ namespace TrackerEnabledDbContext.Identity
         /// </summary>
         /// <param name="tableName">Name of table</param>
         /// <returns></returns>
-        public IQueryable<AuditLog> GetLogs(string tableName)
+        public IQueryable<AuditLog> GetLogs(string tableName, params Expression<Func<AuditLog, object>>[] includeExpressions)
         {
-            return CommonTracker.GetLogs(this, tableName);
+            return CommonTracker.GetLogs(this, tableName, includeExpressions);
         }
 
         /// <summary>

--- a/TrackerEnabledDbContext/TrackerContext.cs
+++ b/TrackerEnabledDbContext/TrackerContext.cs
@@ -12,6 +12,9 @@ using TrackerEnabledDbContext.Common.Models;
 
 namespace TrackerEnabledDbContext
 {
+    using System;
+    using System.Linq.Expressions;
+
     public class TrackerContext : DbContext, ITrackerContext
     {
         public TrackerContext()
@@ -84,9 +87,9 @@ namespace TrackerEnabledDbContext
         /// </summary>
         /// <param name="entityName">full name of entity</param>
         /// <returns></returns>
-        public IQueryable<AuditLog> GetLogs(string entityName)
+        public IQueryable<AuditLog> GetLogs(string entityName, params Expression<Func<AuditLog, object>>[] includeExpressions)
         {
-            return CommonTracker.GetLogs(this, entityName);
+            return CommonTracker.GetLogs(this, entityName, includeExpressions);
         }
 
         /// <summary>


### PR DESCRIPTION
Modified GetLogs(context, string) to include a third parameter 'includeExpressions'. includeExpressions will designate any child entities that needs to be eagerly loaded on the db call. This is particularly useful for those who have LazyLoading off