### PR TITLE
Add the entity being logged to the AuditLogGeneratedEventArgs

### DIFF
--- a/TrackerEnabledDbContext.Common/CoreTracker.cs
+++ b/TrackerEnabledDbContext.Common/CoreTracker.cs
@@ -38,7 +38,7 @@ namespace TrackerEnabledDbContext.Common
 
                     if (record != null)
                     {
-                        var arg = new AuditLogGeneratedEventArgs(record);
+                        var arg = new AuditLogGeneratedEventArgs(record, ent.Entity);
                         RaiseOnAuditLogGenerated(this, arg);
                         if (!arg.SkipSaving)
                         {
@@ -88,7 +88,7 @@ namespace TrackerEnabledDbContext.Common
                     AuditLog record = auditer.CreateLogRecord(userName, EventType.Added, _context);
                     if (record != null)
                     {
-                        var arg = new AuditLogGeneratedEventArgs(record);
+                        var arg = new AuditLogGeneratedEventArgs(record, ent.Entity);
                         RaiseOnAuditLogGenerated(this, arg);
                         if (!arg.SkipSaving)
                         {

--- a/TrackerEnabledDbContext.Common/EventArgs/AuditLogGeneratedEventArgs.cs
+++ b/TrackerEnabledDbContext.Common/EventArgs/AuditLogGeneratedEventArgs.cs
@@ -4,12 +4,15 @@ namespace TrackerEnabledDbContext.Common.EventArgs
 {
     public class AuditLogGeneratedEventArgs : System.EventArgs
     {
-        public AuditLogGeneratedEventArgs(AuditLog log)
+        public AuditLogGeneratedEventArgs(AuditLog log, object entity)
         {
             Log = log;
+            Entity = entity;
         }
 
         public AuditLog Log { get; internal set; }
+
+        public object Entity { get; internal set; }
 
         public bool SkipSaving { get; set; } = false;
     }

--- a/TrackerEnabledDbContext.Identity.IntegrationTests/EventTestsForIdentity.cs
+++ b/TrackerEnabledDbContext.Identity.IntegrationTests/EventTestsForIdentity.cs
@@ -252,6 +252,55 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
             }
         }
 
+        [TestMethod]
+        public void CanChangeEntityInEvent()
+        {
+            using (var context = GetNewContextInstance())
+            {
+                EntityTracker.TrackAllProperties<TrackedModelWithMultipleProperties>();
+
+                bool eventRaised = false;
+
+                string modifiedValue = RandomText;
+
+                context.OnAuditLogGenerated += (sender, args) =>
+                {
+                    var eventEntity = args.Entity as TrackedModelWithMultipleProperties;
+
+                    if (args.Log.EventType == EventType.Modified &&
+                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName &&
+                        eventEntity != null)
+                    {
+                        eventEntity.Name = modifiedValue;
+                        eventRaised = true;
+                    }
+                };
+
+                var existingEntity = GetObjectFactory<TrackedModelWithMultipleProperties>()
+                    .Create(save: true, testDbContext: context);
+
+                string originalValue = existingEntity.Name;
+                string newValue = RandomText;
+                existingEntity.Name = newValue;
+
+                context.SaveChanges();
+
+                //assert
+                Assert.IsTrue(eventRaised);
+
+                existingEntity.AssertAuditForModification(context, existingEntity.Id, null,
+                    new AuditLogDetail
+                    {
+                        PropertyName = nameof(existingEntity.Name),
+                        OriginalValue = originalValue,
+                        NewValue = newValue
+                    });
+
+                context.Entry(existingEntity).Reload();
+                Assert.AreEqual(existingEntity.Name, modifiedValue);
+            }
+        }
+
         private ITestDbContext GetNewContextInstance()
         {
             return new TestTrackerIdentityContext();

--- a/TrackerEnabledDbContext.Identity.IntegrationTests/EventTestsForIdentity.cs
+++ b/TrackerEnabledDbContext.Identity.IntegrationTests/EventTestsForIdentity.cs
@@ -21,8 +21,11 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as TrackedModelWithMultipleProperties;
+
                     if (args.Log.EventType == EventType.Added &&
-                        args.Log.TypeFullName == typeof (TrackedModelWithMultipleProperties).FullName)
+                        args.Log.TypeFullName == typeof (TrackedModelWithMultipleProperties).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                     }
@@ -58,8 +61,11 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as TrackedModelWithMultipleProperties;
+
                     if (args.Log.EventType == EventType.Modified &&
-                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName)
+                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName &&
+                        eventEntity != null)
                     {
                         modifyEventRaised = true;
                     }
@@ -97,8 +103,11 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as NormalModel;
+
                     if (args.Log.EventType == EventType.Deleted &&
-                        args.Log.TypeFullName == typeof(NormalModel).FullName)
+                        args.Log.TypeFullName == typeof(NormalModel).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                     }
@@ -133,8 +142,11 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as SoftDeletableModel;
+
                     if (args.Log.EventType == EventType.SoftDeleted &&
-                        args.Log.TypeFullName == typeof(SoftDeletableModel).FullName)
+                        args.Log.TypeFullName == typeof(SoftDeletableModel).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                     }
@@ -174,8 +186,11 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as SoftDeletableModel;
+
                     if (args.Log.EventType == EventType.UnDeleted &&
-                        args.Log.TypeFullName == typeof(SoftDeletableModel).FullName)
+                        args.Log.TypeFullName == typeof(SoftDeletableModel).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                     }
@@ -216,8 +231,11 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as TrackedModelWithMultipleProperties;
+
                     if (args.Log.EventType == EventType.Added &&
-                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName)
+                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                         args.SkipSaving = true;

--- a/TrackerEnabledDbContext.IntegrationTests/EventTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/EventTests.cs
@@ -21,8 +21,11 @@ namespace TrackerEnabledDbContext.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as TrackedModelWithMultipleProperties;
+
                     if (args.Log.EventType == EventType.Added &&
-                        args.Log.TypeFullName == typeof (TrackedModelWithMultipleProperties).FullName)
+                        args.Log.TypeFullName == typeof (TrackedModelWithMultipleProperties).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                     }
@@ -58,8 +61,11 @@ namespace TrackerEnabledDbContext.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as TrackedModelWithMultipleProperties;
+
                     if (args.Log.EventType == EventType.Modified &&
-                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName)
+                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName &&
+                        eventEntity != null)
                     {
                         modifyEventRaised = true;
                     }
@@ -97,8 +103,11 @@ namespace TrackerEnabledDbContext.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as NormalModel;
+
                     if (args.Log.EventType == EventType.Deleted &&
-                        args.Log.TypeFullName == typeof(NormalModel).FullName)
+                        args.Log.TypeFullName == typeof(NormalModel).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                     }
@@ -133,8 +142,11 @@ namespace TrackerEnabledDbContext.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as SoftDeletableModel;
+
                     if (args.Log.EventType == EventType.SoftDeleted &&
-                        args.Log.TypeFullName == typeof(SoftDeletableModel).FullName)
+                        args.Log.TypeFullName == typeof(SoftDeletableModel).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                     }
@@ -174,8 +186,11 @@ namespace TrackerEnabledDbContext.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as SoftDeletableModel;
+
                     if (args.Log.EventType == EventType.UnDeleted &&
-                        args.Log.TypeFullName == typeof(SoftDeletableModel).FullName)
+                        args.Log.TypeFullName == typeof(SoftDeletableModel).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                     }
@@ -216,8 +231,11 @@ namespace TrackerEnabledDbContext.IntegrationTests
 
                 context.OnAuditLogGenerated += (sender, args) =>
                 {
+                    var eventEntity = args.Entity as TrackedModelWithMultipleProperties;
+
                     if (args.Log.EventType == EventType.Added &&
-                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName)
+                        args.Log.TypeFullName == typeof(TrackedModelWithMultipleProperties).FullName &&
+                        eventEntity != null)
                     {
                         eventRaised = true;
                         args.SkipSaving = true;


### PR DESCRIPTION
It might be helpful to add the entity being logged to the `AuditLogGeneratedEventArgs`.

```c#
public class AuditLogGeneratedEventArgs : System.EventArgs
{
    public AuditLogGeneratedEventArgs(AuditLog log, object entity)
    {
        Log = log;
        Entity = entity;
    }

    public AuditLog Log { get; internal set; }

    public object Entity { get; internal set; }

    public bool SkipSaving { get; set; } = false;
 }
```

This change would allow the user to modify the entity itself it necessary when subscribing to the event. Which could be useful in setting a `LastUpdatedDate` or `LastUpdateBy` column. 