### PR TITLE
Added Culture overide for audit logs

### DIFF
--- a/TrackerEnabledDbContext.Common/Auditors/ChangeLogDetailsAuditor.cs
+++ b/TrackerEnabledDbContext.Common/Auditors/ChangeLogDetailsAuditor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
+using System.Globalization;
 using TrackerEnabledDbContext.Common.Auditors.Comparators;
 using TrackerEnabledDbContext.Common.Configuration;
 using TrackerEnabledDbContext.Common.Extensions;
@@ -34,8 +35,8 @@ namespace TrackerEnabledDbContext.Common.Auditors
                     yield return new AuditLogDetail
                     {
                         PropertyName = propertyName,
-                        OriginalValue = OriginalValue(propertyName)?.ToString(),
-                        NewValue = CurrentValue(propertyName)?.ToString(),
+                        OriginalValue = OriginalValue(propertyName)?.ToString(GlobalTrackingConfig.LogCulture),
+                        NewValue = CurrentValue(propertyName)?.ToString(GlobalTrackingConfig.LogCulture),
                         Log = _log
                     };
                 }

--- a/TrackerEnabledDbContext.Common/Auditors/LogAuditor.cs
+++ b/TrackerEnabledDbContext.Common/Auditors/LogAuditor.cs
@@ -44,7 +44,7 @@ namespace TrackerEnabledDbContext.Common.Auditors
                 EventDateUTC = changeTime,
                 EventType = eventType,
                 TypeFullName = entityType.FullName,
-                RecordId = GetPrimaryKeyValuesOf(_dbEntry, keyNames).ToString()
+                RecordId = GetPrimaryKeyValuesOf(_dbEntry, keyNames).ToString(GlobalTrackingConfig.LogCulture)
             };
 
             var detailsAuditor = GetDetailsAuditor(eventType, newlog);
@@ -94,7 +94,7 @@ namespace TrackerEnabledDbContext.Common.Auditors
                 string output = "[";
 
                 output += string.Join(",",
-                    properties.Select(colName => dbEntry.GetDatabaseValues().GetValue<object>(colName.PropertyName)));
+                    properties.Select(colName => dbEntry.GetDatabaseValues().GetValue<object>(colName.PropertyName).ToString(GlobalTrackingConfig.LogCulture)));
 
                 output += "]";
                 return output;

--- a/TrackerEnabledDbContext.Common/Configuration/GlobalTrackingConfig.cs
+++ b/TrackerEnabledDbContext.Common/Configuration/GlobalTrackingConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq.Expressions;
 using TrackerEnabledDbContext.Common.Extensions;
 
@@ -11,6 +12,16 @@ namespace TrackerEnabledDbContext.Common.Configuration
         public static bool TrackEmptyPropertiesOnAdditionAndDeletion { get; set; } = false;
 
         public static bool DisconnectedContext { get; set; } = false;
+
+        public static CultureInfo CultureOverride { get; set; } = null;
+
+        public static CultureInfo LogCulture 
+        { 
+            get
+            {
+                return CultureOverride ?? CultureInfo.CurrentCulture; 
+            } 
+        }
 
         /// <summary>
         /// This will clear all the configuration done by tracking fluent API.

--- a/TrackerEnabledDbContext.Common/Extensions/ObjectExtensions.cs
+++ b/TrackerEnabledDbContext.Common/Extensions/ObjectExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackerEnabledDbContext.Common.Extensions
+{
+    public static class ObjectExtensions
+    {
+        public static string ToString(this object obj, CultureInfo cultureInfo)
+        {
+            return obj is IConvertible ? ((IConvertible)obj).ToString(cultureInfo)
+                : obj is IFormattable ? ((IFormattable)obj).ToString(null, cultureInfo)
+                : obj.ToString();
+        }
+    }
+}

--- a/TrackerEnabledDbContext.Common/TrackerEnabledDbContext.Common.csproj
+++ b/TrackerEnabledDbContext.Common/TrackerEnabledDbContext.Common.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Configuration\TrackingConfigurationValue.cs" />
     <Compile Include="EventArgs\AuditLogGeneratedEventArgs.cs" />
     <Compile Include="Extensions\EntityTypeConfigurationExtensions.cs" />
+    <Compile Include="Extensions\ObjectExtensions.cs" />
     <Compile Include="Interfaces\ILogDetailsAuditor.cs" />
     <Compile Include="Interfaces\IUnTrackable.cs" />
     <Compile Include="Attributes\SkipTrackingAttribute.cs" />


### PR DESCRIPTION
Here is a pass at adding culture control to the logging.

If not specified it will continue to use the current culture, but when set it will use the specified culture for NewValue and OldValue in audit details and the key in the audit table.

I know a decimal key is not very likely.  A date still not common but I can see it used.  Either way an application that uses multiple cultures would create very difficult to use logs if the keys were in multiple cultures.