### PR TITLE
Added support for complex types - fixes #86 and #122

### DIFF
--- a/TrackerEnabledDbContext.Common.Testing/ITestDbContext.cs
+++ b/TrackerEnabledDbContext.Common.Testing/ITestDbContext.cs
@@ -16,5 +16,6 @@ namespace TrackerEnabledDbContext.Common.Testing
         DbSet<TrackedModelWithMultipleProperties> TrackedModelsWithMultipleProperties { get; set; }
         DbSet<TrackedModelWithCustomTableAndColumnNames> TrackedModelsWithCustomTableAndColumnNames { get; set; }
         DbSet<SoftDeletableModel> SoftDeletableModels { get; set; }
+        DbSet<ModelWithComplexType> ModelsWithComplexType { get; set; }
     }
 }

--- a/TrackerEnabledDbContext.Common.Testing/Models/ModelWithComplexType.cs
+++ b/TrackerEnabledDbContext.Common.Testing/Models/ModelWithComplexType.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackerEnabledDbContext.Common.Testing.Models
+{
+    [TrackChanges]
+    public class ModelWithComplexType
+    {
+        public long Id { get; set; }
+        public ComplexType ComplexType { get; set; }
+    }
+
+    public class ComplexType
+    {
+        public string Property1 { get; set; }
+        public string Property2 { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var other = obj as ComplexType;
+
+            return Property1 == other.Property1;
+        }
+
+        public override int GetHashCode()
+        {
+            return Property1.GetHashCode();
+        }
+    }
+}

--- a/TrackerEnabledDbContext.Common.Testing/TrackerEnabledDbContext.Common.Testing.csproj
+++ b/TrackerEnabledDbContext.Common.Testing/TrackerEnabledDbContext.Common.Testing.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ITestDbContext.cs" />
     <Compile Include="LogDetailsEqualityComparer.cs" />
     <Compile Include="Models\ChildModel.cs" />
+    <Compile Include="Models\ModelWithComplexType.cs" />
     <Compile Include="Models\ModelWithCompositeKey.cs" />
     <Compile Include="Models\ModelWithConventionalKey.cs" />
     <Compile Include="Models\SoftDeletableModel.cs" />

--- a/TrackerEnabledDbContext.Identity.IntegrationTests/TestTrackerIdentityContext .cs
+++ b/TrackerEnabledDbContext.Identity.IntegrationTests/TestTrackerIdentityContext .cs
@@ -8,7 +8,7 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
 {
     public class TestTrackerIdentityContext : TrackerIdentityContext<IdentityUser>, ITestDbContext
     {
-        protected static readonly string TestConnectionString = Environment.GetEnvironmentVariable("TestGenericConnectionString") 
+        protected static readonly string TestConnectionString = Environment.GetEnvironmentVariable("TestGenericConnectionString")
             ?? "DefaultTestConnection";
 
         public TestTrackerIdentityContext()
@@ -27,5 +27,7 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
         public DbSet<TrackedModelWithMultipleProperties> TrackedModelsWithMultipleProperties { get; set; }
         public DbSet<TrackedModelWithCustomTableAndColumnNames> TrackedModelsWithCustomTableAndColumnNames { get; set; }
         public DbSet<SoftDeletableModel> SoftDeletableModels { get; set; }
+
+        public DbSet<ModelWithComplexType> ModelsWithComplexType { get; set; }
     }
 }

--- a/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
@@ -7,7 +7,7 @@ namespace TrackerEnabledDbContext.IntegrationTests
 {
     public class TestTrackerContext : TrackerContext, ITestDbContext
     {
-        protected static readonly string TestConnectionString = Environment.GetEnvironmentVariable("TestGenericConnectionString") 
+        protected static readonly string TestConnectionString = Environment.GetEnvironmentVariable("TestGenericConnectionString")
             ?? "DefaultTestConnection";
 
         public TestTrackerContext()
@@ -26,5 +26,6 @@ namespace TrackerEnabledDbContext.IntegrationTests
         public DbSet<TrackedModelWithMultipleProperties> TrackedModelsWithMultipleProperties { get; set; }
         public DbSet<TrackedModelWithCustomTableAndColumnNames> TrackedModelsWithCustomTableAndColumnNames { get; set; }
         public DbSet<SoftDeletableModel> SoftDeletableModels { get; set; }
+        public DbSet<ModelWithComplexType> ModelsWithComplexType { get; set; }
     }
 }

--- a/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
@@ -239,6 +239,7 @@ namespace TrackerEnabledDbContext.IntegrationTests
             string oldDescription = RandomText;
             string newDescription = RandomText;
 
+            //only set one of the properties on the complex type
             var complexType = new ComplexType { Property1 = oldDescription };
             var entity = new ModelWithComplexType { ComplexType = complexType };
 

--- a/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
@@ -233,6 +233,38 @@ namespace TrackerEnabledDbContext.IntegrationTests
         }
 
         [TestMethod]
+        public void Can_track_complex_type_property_change()
+        {
+            //add enity
+            string oldDescription = RandomText;
+            string newDescription = RandomText;
+
+            var complexType = new ComplexType { Property1 = oldDescription };
+            var entity = new ModelWithComplexType { ComplexType = complexType };
+
+            Db.Entry(entity).State = EntityState.Added;
+            Db.SaveChanges();
+
+            //modify entity
+            entity.ComplexType.Property1 = newDescription;
+            Db.SaveChanges();
+
+            AuditLogDetail[] expectedLog = new List<AuditLogDetail>
+            {
+                new AuditLogDetail
+                {
+                    NewValue = newDescription,
+                    OriginalValue = oldDescription,
+                    PropertyName = "ComplexType_Property1"
+                }
+            }.ToArray();
+
+
+            //assert
+            entity.AssertAuditForModification(Db, entity.Id, null, expectedLog);
+        }
+
+        [TestMethod]
         public async Task Can_skip_tracking_of_property()
         {
             string username = RandomText;


### PR DESCRIPTION
fixes #86 and #122 
I only added support for "shallow" complex types. I think this will cover most, if not all, of the use cases.

If the complex types are nested (complex type has a property that is another complex type) the code will need to be updated to recursively parse the classes.