### PR TITLE
Allow tracking to be disabled per instance of dbcontext

### DIFF
--- a/TrackerEnabledDbContext.Common/Interfaces/ITrackerContext.cs
+++ b/TrackerEnabledDbContext.Common/Interfaces/ITrackerContext.cs
@@ -12,6 +12,7 @@ namespace TrackerEnabledDbContext.Common.Interfaces
     {
         DbSet<AuditLog> AuditLog { get; set; }
         DbSet<AuditLogDetail> LogDetails { get; set; }
+        bool TrackingEnabled { get; set; }
 
         event EventHandler<AuditLogGeneratedEventArgs> OnAuditLogGenerated;
 

--- a/TrackerEnabledDbContext.Identity.IntegrationTests/TrackerIdentityContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.Identity.IntegrationTests/TrackerIdentityContextIntegrationTests.cs
@@ -413,5 +413,20 @@ namespace TrackerEnabledDbContext.Identity.IntegrationTests
             var auditLogDetails = auditor.CreateLogDetails().ToList();
             Db.Database.Log = null;
         }
+
+
+
+        [TestMethod]
+        public void Can_recognise_context_tracking_indicator_when_disabled()
+        {
+
+            NormalModel model = ObjectFactory.Create<NormalModel>();
+            Db.NormalModels.Add(model);
+
+            Db.TrackingEnabled = false;
+            Db.SaveChanges();
+
+            model.AssertNoLogs(Db, model.Id);
+        }
     }
 }

--- a/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
+++ b/TrackerEnabledDbContext.Identity/TrackerIdentityContext.cs
@@ -34,6 +34,19 @@ namespace TrackerEnabledDbContext.Identity
         private string _defaultUsername;
         private Action<dynamic> _metadataConfiguration;
 
+        private bool _trackingEnabled = true;
+        public bool TrackingEnabled
+        {
+            get
+            {
+                return GlobalTrackingConfig.Enabled && _trackingEnabled;
+            }
+            set
+            {
+                _trackingEnabled = value;
+            }
+        }
+
         public virtual void ConfigureUsername(Func<string> usernameFactory)
         {
             _usernameFactory = usernameFactory;
@@ -101,7 +114,7 @@ namespace TrackerEnabledDbContext.Identity
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual int SaveChanges(object userName)
         {
-            if (!GlobalTrackingConfig.Enabled)
+            if (!TrackingEnabled)
             {
                 return base.SaveChanges();
             }
@@ -131,7 +144,7 @@ namespace TrackerEnabledDbContext.Identity
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public override int SaveChanges()
         {
-            if (!GlobalTrackingConfig.Enabled)
+            if (!TrackingEnabled)
             {
                 return base.SaveChanges();
             }
@@ -195,7 +208,7 @@ namespace TrackerEnabledDbContext.Identity
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual async Task<int> SaveChangesAsync(object userName, CancellationToken cancellationToken)
         {
-            if (!GlobalTrackingConfig.Enabled)
+            if (!TrackingEnabled)
             {
                 return await base.SaveChangesAsync(cancellationToken);
             }
@@ -230,7 +243,7 @@ namespace TrackerEnabledDbContext.Identity
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual async Task<int> SaveChangesAsync(int userId)
         {
-            if (!GlobalTrackingConfig.Enabled)
+            if (!TrackingEnabled)
             {
                 return await base.SaveChangesAsync(CancellationToken.None);
             }
@@ -246,7 +259,7 @@ namespace TrackerEnabledDbContext.Identity
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual async Task<int> SaveChangesAsync(string userName)
         {
-            if (!GlobalTrackingConfig.Enabled)
+            if (!TrackingEnabled)
             {
                 return await base.SaveChangesAsync(CancellationToken.None);
             }
@@ -264,7 +277,7 @@ namespace TrackerEnabledDbContext.Identity
         /// </returns>
         public override async Task<int> SaveChangesAsync()
         {
-            if (!GlobalTrackingConfig.Enabled)
+            if (!TrackingEnabled)
             {
                 return await base.SaveChangesAsync(CancellationToken.None);
             }
@@ -286,7 +299,7 @@ namespace TrackerEnabledDbContext.Identity
         /// </returns>
         public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken)
         {
-            if (!GlobalTrackingConfig.Enabled)
+            if (!TrackingEnabled)
             {
                 return await base.SaveChangesAsync(cancellationToken);
             }

--- a/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TrackerContextIntegrationTests.cs
@@ -529,5 +529,20 @@ namespace TrackerEnabledDbContext.IntegrationTests
                 x => x.StartDate,
                 x => x.Value);
         }
+
+
+
+        [TestMethod]
+        public void Can_recognise_context_tracking_indicator_when_disabled()
+        {
+
+            NormalModel model = ObjectFactory.Create<NormalModel>();
+            Db.NormalModels.Add(model);
+
+            Db.TrackingEnabled = false;
+            Db.SaveChanges();
+
+            model.AssertNoLogs(Db, model.Id);
+        }
     }
 }

--- a/TrackerEnabledDbContext/TrackerContext.cs
+++ b/TrackerEnabledDbContext/TrackerContext.cs
@@ -27,6 +27,21 @@ namespace TrackerEnabledDbContext
         private string _defaultUsername;
         private Action<dynamic> _metadataConfiguration;
 
+
+        private bool _trackingEnabled = true;
+
+        public bool TrackingEnabled
+        {
+            get
+            {
+                return GlobalTrackingConfig.Enabled && _trackingEnabled;
+            }
+            set
+            {
+                _trackingEnabled = value;
+            }
+        }
+
         public virtual void ConfigureUsername(Func<string> usernameFactory)
         {
             _usernameFactory = usernameFactory;
@@ -102,7 +117,7 @@ namespace TrackerEnabledDbContext
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual int SaveChanges(object userName)
         {
-            if (!GlobalTrackingConfig.Enabled) return base.SaveChanges();
+            if (!TrackingEnabled) return base.SaveChanges();
 
             dynamic metaData = new ExpandoObject();
             _metadataConfiguration?.Invoke(metaData);
@@ -128,7 +143,7 @@ namespace TrackerEnabledDbContext
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public override int SaveChanges()
         {
-            if (!GlobalTrackingConfig.Enabled) return base.SaveChanges();
+            if (!TrackingEnabled) return base.SaveChanges();
 
             return SaveChanges(_usernameFactory?.Invoke() ?? _defaultUsername);
         }
@@ -189,7 +204,7 @@ namespace TrackerEnabledDbContext
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual async Task<int> SaveChangesAsync(object userName, CancellationToken cancellationToken)
         {
-            if (!GlobalTrackingConfig.Enabled) return await base.SaveChangesAsync(cancellationToken);
+            if (!TrackingEnabled) return await base.SaveChangesAsync(cancellationToken);
 
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
@@ -221,7 +236,7 @@ namespace TrackerEnabledDbContext
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual async Task<int> SaveChangesAsync(int userId)
         {
-            if (!GlobalTrackingConfig.Enabled) return await base.SaveChangesAsync(CancellationToken.None);
+            if (!TrackingEnabled) return await base.SaveChangesAsync(CancellationToken.None);
 
             return await SaveChangesAsync(userId, CancellationToken.None);
         }
@@ -234,7 +249,7 @@ namespace TrackerEnabledDbContext
         /// <returns>Returns the number of objects written to the underlying database.</returns>
         public virtual async Task<int> SaveChangesAsync(string userName)
         {
-            if (!GlobalTrackingConfig.Enabled) return await base.SaveChangesAsync(CancellationToken.None);
+            if (!TrackingEnabled) return await base.SaveChangesAsync(CancellationToken.None);
 
             return await SaveChangesAsync(userName, CancellationToken.None);
         }
@@ -249,7 +264,7 @@ namespace TrackerEnabledDbContext
         /// </returns>
         public override async Task<int> SaveChangesAsync()
         {
-            if (!GlobalTrackingConfig.Enabled) return await base.SaveChangesAsync(CancellationToken.None);
+            if (!TrackingEnabled) return await base.SaveChangesAsync(CancellationToken.None);
 
             return await SaveChangesAsync(_usernameFactory?.Invoke() ?? _defaultUsername, CancellationToken.None);
         }
@@ -268,7 +283,7 @@ namespace TrackerEnabledDbContext
         /// </returns>
         public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken)
         {
-            if (!GlobalTrackingConfig.Enabled) return await base.SaveChangesAsync(cancellationToken);
+            if (!TrackingEnabled) return await base.SaveChangesAsync(cancellationToken);
 
             return await SaveChangesAsync(_usernameFactory?.Invoke() ?? _defaultUsername, cancellationToken);
         }


### PR DESCRIPTION
added context specific tracking enabled indicator in ITrackerContext and utilized GlobalTrackingConfig.Enabled and local tracking enabled property in SaveChanges methods when determining if tracking is enabled.  Included unit test for TrackerContext and TrackerIdentityContext.

This allows a user to turn on/off db tracking in the middle of a single dbcontext instance.

We had discussed this functionality in the past but I did not come around to implementing until now.