### PR TITLE
#90 Fluent API for excluding fields does not work with base classes

### DIFF
--- a/TrackerEnabledDbContext.Common.Testing/Models/ModelInheritance.cs
+++ b/TrackerEnabledDbContext.Common.Testing/Models/ModelInheritance.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace TrackerEnabledDbContext.Common.Testing.Models
+{
+    public abstract class BaseModel
+    {
+        public int Id { get; set; }
+
+        public DateTime Modified { get; set; }
+    }
+
+    public class ExtendedModel : BaseModel
+    {
+        public string TrackedProperty { get; set; }
+    }
+}

--- a/TrackerEnabledDbContext.Common.Testing/TrackerEnabledDbContext.Common.Testing.csproj
+++ b/TrackerEnabledDbContext.Common.Testing/TrackerEnabledDbContext.Common.Testing.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ITestDbContext.cs" />
     <Compile Include="LogDetailsEqualityComparer.cs" />
     <Compile Include="Models\ChildModel.cs" />
+    <Compile Include="Models\ModelInheritance.cs" />
     <Compile Include="Models\ModelWithComplexType.cs" />
     <Compile Include="Models\ModelWithCompositeKey.cs" />
     <Compile Include="Models\ModelWithConventionalKey.cs" />

--- a/TrackerEnabledDbContext.Common/Auditors/ChangeLogDetailsAuditor.cs
+++ b/TrackerEnabledDbContext.Common/Auditors/ChangeLogDetailsAuditor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using TrackerEnabledDbContext.Common.Auditors.Comparators;
+using TrackerEnabledDbContext.Common.Auditors.Helpers;
 using TrackerEnabledDbContext.Common.Configuration;
 using TrackerEnabledDbContext.Common.Extensions;
 using TrackerEnabledDbContext.Common.Interfaces;
@@ -14,11 +15,13 @@ namespace TrackerEnabledDbContext.Common.Auditors
     {
         protected readonly DbEntityEntry DbEntry;
         private readonly AuditLog _log;
+        private readonly DbEntryValuesWrapper _dbEntryValuesWrapper;
 
         public ChangeLogDetailsAuditor(DbEntityEntry dbEntry, AuditLog log)
         {
             DbEntry = dbEntry;
             _log = log;
+            _dbEntryValuesWrapper = new DbEntryValuesWrapper(dbEntry);
         }
 
         public IEnumerable<AuditLogDetail> CreateLogDetails()
@@ -81,18 +84,7 @@ namespace TrackerEnabledDbContext.Common.Auditors
 
         protected virtual object OriginalValue(string propertyName)
         {
-            object originalValue = null;
-
-            if (GlobalTrackingConfig.DisconnectedContext)
-            {
-                originalValue = DbEntry.GetDatabaseValues().GetValue<object>(propertyName);
-            }
-            else
-            {
-                originalValue = DbEntry.Property(propertyName).OriginalValue;
-            }
-
-            return originalValue;
+            return _dbEntryValuesWrapper.OriginalValue(propertyName);
         }
 
         protected virtual object CurrentValue(string propertyName)

--- a/TrackerEnabledDbContext.Common/Auditors/Helpers/DbEntryValuesWrapper.cs
+++ b/TrackerEnabledDbContext.Common/Auditors/Helpers/DbEntryValuesWrapper.cs
@@ -1,0 +1,34 @@
+﻿using System.Data.Entity.Infrastructure;
+using TrackerEnabledDbContext.Common.Configuration;
+
+namespace TrackerEnabledDbContext.Common.Auditors.Helpers
+{
+    public class DbEntryValuesWrapper
+    {
+        protected readonly DbEntityEntry _dbEntry;
+        private DbPropertyValues _entryValues = null;
+
+        private DbPropertyValues EntryPropertyValues => _entryValues ?? (_entryValues = _dbEntry.GetDatabaseValues());
+
+        public DbEntryValuesWrapper(DbEntityEntry dbEntry)
+        {
+            _dbEntry = dbEntry;
+        }
+
+        public object OriginalValue(string propertyName)
+        {
+            object originalValue = null;
+
+            if (GlobalTrackingConfig.DisconnectedContext)
+            {
+                originalValue = EntryPropertyValues.GetValue<object>(propertyName);
+            }
+            else
+            {
+                originalValue = _dbEntry.Property(propertyName).OriginalValue;
+            }
+
+            return originalValue;
+        }
+    }
+}

--- a/TrackerEnabledDbContext.Common/Configuration/OverrideTrackingResponse.cs
+++ b/TrackerEnabledDbContext.Common/Configuration/OverrideTrackingResponse.cs
@@ -52,7 +52,7 @@ namespace TrackerEnabledDbContext.Common.Configuration
             var newValue = new TrackingConfigurationValue(false, TrackingConfigurationPriority.High);
 
             TrackingDataStore.PropertyConfigStore.AddOrUpdate(
-                new PropertyConfiguerationKey(info.Name, info.DeclaringType.FullName),
+                new PropertyConfiguerationKey(info.Name, typeof(T).FullName),
                 newValue,
                 (existingKey, existingvalue) => newValue);
         }

--- a/TrackerEnabledDbContext.Common/TrackerEnabledDbContext.Common.csproj
+++ b/TrackerEnabledDbContext.Common/TrackerEnabledDbContext.Common.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Auditors\Comparators\StringComparator.cs" />
     <Compile Include="Auditors\Comparators\ValueTypeComparator.cs" />
     <Compile Include="Auditors\DeletetionLogDetailsAuditor.cs" />
+    <Compile Include="Auditors\Helpers\DbEntryValuesWrapper.cs" />
     <Compile Include="Auditors\SoftDeletedLogDetailsAuditor.cs" />
     <Compile Include="Auditors\UnDeletedLogDetailsAudotor.cs" />
     <Compile Include="Configuration\DbContextExtensions.cs" />

--- a/TrackerEnabledDbContext.IntegrationTests/FluentConfigurationTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/FluentConfigurationTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TrackerEnabledDbContext.Common.Configuration;
+using TrackerEnabledDbContext.Common.Models;
 using TrackerEnabledDbContext.Common.Testing;
 using TrackerEnabledDbContext.Common.Testing.Extensions;
 using TrackerEnabledDbContext.Common.Testing.Models;
@@ -102,5 +103,45 @@ namespace TrackerEnabledDbContext.IntegrationTests
         }
 
         //TODO: can track CHAR properties ? NO
+
+        [TestMethod]
+        public void CanTrackBaseClassProperties()
+        {
+            EntityTracker
+                .TrackAllProperties<ExtendedModel>()
+                .Except(m => m.Modified);
+
+            var existingEntity = ObjectFactory.Create<ExtendedModel>(save: true, testDbContext: Db);
+
+            var originalValue = existingEntity.TrackedProperty;
+            var newValue = RandomText;
+            existingEntity.TrackedProperty = newValue;
+
+            Db.SaveChanges();
+
+            existingEntity.AssertAuditForModification(Db, existingEntity.Id, null,
+                new AuditLogDetail
+                {
+                    PropertyName = nameof(existingEntity.TrackedProperty),
+                    OriginalValue = originalValue,
+                    NewValue = newValue
+                });
+        }
+
+        [TestMethod]
+        public void ShouldSkipUntrackedBaseClassProperties()
+        {
+            EntityTracker
+                .TrackAllProperties<ExtendedModel>()
+                .Except(m => m.Modified);
+
+            var existingEntity = ObjectFactory.Create<ExtendedModel>(save: true, testDbContext: Db);
+
+            existingEntity.Modified = RandomDate;
+
+            Db.SaveChanges();
+
+            existingEntity.AssertNoLogs(Db, existingEntity.Id, EventType.Modified);
+        }
     }
 }

--- a/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
@@ -27,5 +27,6 @@ namespace TrackerEnabledDbContext.IntegrationTests
         public DbSet<TrackedModelWithCustomTableAndColumnNames> TrackedModelsWithCustomTableAndColumnNames { get; set; }
         public DbSet<SoftDeletableModel> SoftDeletableModels { get; set; }
         public DbSet<ModelWithComplexType> ModelsWithComplexType { get; set; }
+        public DbSet<ExtendedModel> ExtendedModels { get; set; }
     }
 }


### PR DESCRIPTION
TrackingDataStore.PropertyConfigStore should not determine types of entities by calling property.GetPropertyInfo(), but should store types specified by the configuring method of fluent API.