### PR TITLE
#90 Fluent API for excluding fields does not work with base classes

### DIFF
--- a/TrackerEnabledDbContext.Common.Testing/Models/ModelInheritance.cs
+++ b/TrackerEnabledDbContext.Common.Testing/Models/ModelInheritance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace TrackerEnabledDbContext.Common.Testing.Models
 {
@@ -7,10 +8,18 @@ namespace TrackerEnabledDbContext.Common.Testing.Models
         public int Id { get; set; }
 
         public DateTime Modified { get; set; }
+
+        [SkipTracking]
+        public string UntrackedProperty { get; set; }
     }
 
     public class ExtendedModel : BaseModel
     {
         public string TrackedProperty { get; set; }
+    }
+
+    [TrackChanges]
+    public class TrackedExtendedModel : BaseModel
+    {
     }
 }

--- a/TrackerEnabledDbContext.Common.Testing/Models/ModelInheritance.cs
+++ b/TrackerEnabledDbContext.Common.Testing/Models/ModelInheritance.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace TrackerEnabledDbContext.Common.Testing.Models
+{
+    public abstract class BaseModel
+    {
+        public int Id { get; set; }
+
+        public DateTime Modified { get; set; }
+    }
+
+    public class ExtendedModel : BaseModel
+    {
+        public string TrackedProperty { get; set; }
+    }
+}

--- a/TrackerEnabledDbContext.Common.Testing/TrackerEnabledDbContext.Common.Testing.csproj
+++ b/TrackerEnabledDbContext.Common.Testing/TrackerEnabledDbContext.Common.Testing.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ITestDbContext.cs" />
     <Compile Include="LogDetailsEqualityComparer.cs" />
     <Compile Include="Models\ChildModel.cs" />
+    <Compile Include="Models\ModelInheritance.cs" />
     <Compile Include="Models\ModelWithComplexType.cs" />
     <Compile Include="Models\ModelWithCompositeKey.cs" />
     <Compile Include="Models\ModelWithConventionalKey.cs" />

--- a/TrackerEnabledDbContext.Common/Configuration/OverrideTrackingResponse.cs
+++ b/TrackerEnabledDbContext.Common/Configuration/OverrideTrackingResponse.cs
@@ -52,7 +52,7 @@ namespace TrackerEnabledDbContext.Common.Configuration
             var newValue = new TrackingConfigurationValue(false, TrackingConfigurationPriority.High);
 
             TrackingDataStore.PropertyConfigStore.AddOrUpdate(
-                new PropertyConfiguerationKey(info.Name, info.DeclaringType.FullName),
+                new PropertyConfiguerationKey(info.Name, typeof(T).FullName),
                 newValue,
                 (existingKey, existingvalue) => newValue);
         }

--- a/TrackerEnabledDbContext.Common/Configuration/OverrideTrackingResponse.cs
+++ b/TrackerEnabledDbContext.Common/Configuration/OverrideTrackingResponse.cs
@@ -62,10 +62,9 @@ namespace TrackerEnabledDbContext.Common.Configuration
             PropertyInfo info = property.GetPropertyInfo();
             var newValue = new TrackingConfigurationValue(true, TrackingConfigurationPriority.High);
             TrackingDataStore.PropertyConfigStore.AddOrUpdate(
-                new PropertyConfiguerationKey(info.Name, info.DeclaringType.FullName),
+                new PropertyConfiguerationKey(info.Name, typeof(T).FullName),
                 newValue,
                 (key, value) => newValue);
         }
-
     }
 }

--- a/TrackerEnabledDbContext.IntegrationTests/FluentConfigurationTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/FluentConfigurationTests.cs
@@ -105,6 +105,30 @@ namespace TrackerEnabledDbContext.IntegrationTests
         //TODO: can track CHAR properties ? NO
 
         [TestMethod]
+        public void CanOverrideUntrackedBaseClassProperties()
+        {
+            EntityTracker
+                .OverrideTracking<TrackedExtendedModel>()
+                .Enable(x => x.UntrackedProperty);
+
+            var existingEntity = ObjectFactory.Create<TrackedExtendedModel>(save: true, testDbContext: Db);
+
+            var originalValue = existingEntity.UntrackedProperty;
+            var newValue = RandomText;
+            existingEntity.UntrackedProperty = newValue;
+
+            Db.SaveChanges();
+
+            existingEntity.AssertAuditForModification(Db, existingEntity.Id, null,
+                new AuditLogDetail
+                {
+                    PropertyName = nameof(existingEntity.UntrackedProperty),
+                    OriginalValue = originalValue,
+                    NewValue = newValue
+                });
+        }
+
+        [TestMethod]
         public void CanTrackBaseClassProperties()
         {
             EntityTracker

--- a/TrackerEnabledDbContext.IntegrationTests/FluentConfigurationTests.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/FluentConfigurationTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TrackerEnabledDbContext.Common.Configuration;
+using TrackerEnabledDbContext.Common.Models;
 using TrackerEnabledDbContext.Common.Testing;
 using TrackerEnabledDbContext.Common.Testing.Extensions;
 using TrackerEnabledDbContext.Common.Testing.Models;
@@ -102,5 +103,45 @@ namespace TrackerEnabledDbContext.IntegrationTests
         }
 
         //TODO: can track CHAR properties ? NO
+
+        [TestMethod]
+        public void CanTrackBaseClassProperties()
+        {
+            EntityTracker
+                .TrackAllProperties<ExtendedModel>()
+                .Except(m => m.Modified);
+
+            var existingEntity = ObjectFactory.Create<ExtendedModel>(save: true, testDbContext: Db);
+
+            var originalValue = existingEntity.TrackedProperty;
+            var newValue = RandomText;
+            existingEntity.TrackedProperty = newValue;
+
+            Db.SaveChanges();
+
+            existingEntity.AssertAuditForModification(Db, existingEntity.Id, null,
+                new AuditLogDetail
+                {
+                    PropertyName = nameof(existingEntity.TrackedProperty),
+                    OriginalValue = originalValue,
+                    NewValue = newValue
+                });
+        }
+
+        [TestMethod]
+        public void ShouldSkipUntrackedBaseClassProperties()
+        {
+            EntityTracker
+                .TrackAllProperties<ExtendedModel>()
+                .Except(m => m.Modified);
+
+            var existingEntity = ObjectFactory.Create<ExtendedModel>(save: true, testDbContext: Db);
+
+            existingEntity.Modified = RandomDate;
+
+            Db.SaveChanges();
+
+            existingEntity.AssertNoLogs(Db, existingEntity.Id, EventType.Modified);
+        }
     }
 }

--- a/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
@@ -27,5 +27,6 @@ namespace TrackerEnabledDbContext.IntegrationTests
         public DbSet<TrackedModelWithCustomTableAndColumnNames> TrackedModelsWithCustomTableAndColumnNames { get; set; }
         public DbSet<SoftDeletableModel> SoftDeletableModels { get; set; }
         public DbSet<ModelWithComplexType> ModelsWithComplexType { get; set; }
+        public DbSet<ExtendedModel> ExtendedModels { get; set; }
     }
 }

--- a/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
+++ b/TrackerEnabledDbContext.IntegrationTests/TestTrackerContext.cs
@@ -28,5 +28,6 @@ namespace TrackerEnabledDbContext.IntegrationTests
         public DbSet<SoftDeletableModel> SoftDeletableModels { get; set; }
         public DbSet<ModelWithComplexType> ModelsWithComplexType { get; set; }
         public DbSet<ExtendedModel> ExtendedModels { get; set; }
+        public DbSet<TrackedExtendedModel> TrackedExtendedModels { get; set; }
     }
 }


### PR DESCRIPTION
TrackingDataStore.PropertyConfigStore should not determine types of entities by calling property.GetPropertyInfo(), but should store types specified by the configuring method of fluent API.